### PR TITLE
build: Only upload the lib folder to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
   },
   "dependencies": {
     "seedrandom": "^3.0.5"
-  }
+  },
+  "files": [
+    "lib"
+  ]
 }


### PR DESCRIPTION
Thanks for the awesome library guys, however, it's gigantic because of your examples folder, any chance you would consider only uploading the lib folder?